### PR TITLE
tableName & bundle support

### DIFF
--- a/Localize_Swift.xcodeproj/project.pbxproj
+++ b/Localize_Swift.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		343A6DEE1D152E5A0081AA37 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 344169461C67539300B93D28 /* Foundation.framework */; };
 		343A6DF01D152E5A0081AA37 /* Localize_Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 3433F2501C518B38003AE34D /* Localize_Swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		344169471C67539300B93D28 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 344169461C67539300B93D28 /* Foundation.framework */; };
+		68A520041DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */; };
+		68A520051DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */; };
+		68A520061DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */; };
+		68A520071DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +50,7 @@
 		343A6DE91D152B1B0081AA37 /* Localize_Swift-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Localize_Swift-tvOS.plist"; path = "/Users/marmelroy/Documents/Projects/OpenSource/Localize/Localize_Swift-tvOS.plist"; sourceTree = "<absolute>"; };
 		343A6DF51D152E5A0081AA37 /* Localize_Swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Localize_Swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		344169461C67539300B93D28 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; name = "String+LocalizeTableName.swift"; path = "Sources/String+LocalizeTableName.swift"; sourceTree = SOURCE_ROOT; tabWidth = 4; usesTabs = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +123,7 @@
 			children = (
 				3433F2501C518B38003AE34D /* Localize_Swift.h */,
 				3433F2511C518B38003AE34D /* Localize.swift */,
+				68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */,
 				3433F23B1C518AF7003AE34D /* Info.plist */,
 				343A6DE91D152B1B0081AA37 /* Localize_Swift-tvOS.plist */,
 				344169461C67539300B93D28 /* Foundation.framework */,
@@ -350,6 +356,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3433F2531C518B38003AE34D /* Localize.swift in Sources */,
+				68A520041DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -366,6 +373,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				343A6DD11D1529560081AA37 /* Localize.swift in Sources */,
+				68A520051DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -374,6 +382,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				343A6DDF1D152B1B0081AA37 /* Localize.swift in Sources */,
+				68A520061DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -382,6 +391,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				343A6DEC1D152E5A0081AA37 /* Localize.swift in Sources */,
+				68A520071DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Localize_Swift.xcodeproj/project.pbxproj
+++ b/Localize_Swift.xcodeproj/project.pbxproj
@@ -21,6 +21,14 @@
 		343A6DEE1D152E5A0081AA37 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 344169461C67539300B93D28 /* Foundation.framework */; };
 		343A6DF01D152E5A0081AA37 /* Localize_Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 3433F2501C518B38003AE34D /* Localize_Swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		344169471C67539300B93D28 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 344169461C67539300B93D28 /* Foundation.framework */; };
+		68973D661DA7AA200076F08A /* String+LocalizeBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68973D651DA7AA200076F08A /* String+LocalizeBundle.swift */; };
+		68973D671DA7AA200076F08A /* String+LocalizeBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68973D651DA7AA200076F08A /* String+LocalizeBundle.swift */; };
+		68973D681DA7AA200076F08A /* String+LocalizeBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68973D651DA7AA200076F08A /* String+LocalizeBundle.swift */; };
+		68973D691DA7AA200076F08A /* String+LocalizeBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68973D651DA7AA200076F08A /* String+LocalizeBundle.swift */; };
+		68973D6B1DA7AB140076F08A /* String+LocalizedBundleTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68973D6A1DA7AB140076F08A /* String+LocalizedBundleTableName.swift */; };
+		68973D6C1DA7AB140076F08A /* String+LocalizedBundleTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68973D6A1DA7AB140076F08A /* String+LocalizedBundleTableName.swift */; };
+		68973D6D1DA7AB140076F08A /* String+LocalizedBundleTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68973D6A1DA7AB140076F08A /* String+LocalizedBundleTableName.swift */; };
+		68973D6E1DA7AB140076F08A /* String+LocalizedBundleTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68973D6A1DA7AB140076F08A /* String+LocalizedBundleTableName.swift */; };
 		68A520041DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */; };
 		68A520051DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */; };
 		68A520061DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */; };
@@ -50,6 +58,8 @@
 		343A6DE91D152B1B0081AA37 /* Localize_Swift-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Localize_Swift-tvOS.plist"; path = "/Users/marmelroy/Documents/Projects/OpenSource/Localize/Localize_Swift-tvOS.plist"; sourceTree = "<absolute>"; };
 		343A6DF51D152E5A0081AA37 /* Localize_Swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Localize_Swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		344169461C67539300B93D28 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		68973D651DA7AA200076F08A /* String+LocalizeBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "String+LocalizeBundle.swift"; path = "Sources/String+LocalizeBundle.swift"; sourceTree = SOURCE_ROOT; };
+		68973D6A1DA7AB140076F08A /* String+LocalizedBundleTableName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "String+LocalizedBundleTableName.swift"; path = "Sources/String+LocalizedBundleTableName.swift"; sourceTree = SOURCE_ROOT; };
 		68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; name = "String+LocalizeTableName.swift"; path = "Sources/String+LocalizeTableName.swift"; sourceTree = SOURCE_ROOT; tabWidth = 4; usesTabs = 0; };
 /* End PBXFileReference section */
 
@@ -124,6 +134,8 @@
 				3433F2501C518B38003AE34D /* Localize_Swift.h */,
 				3433F2511C518B38003AE34D /* Localize.swift */,
 				68A520031DA6D5FD00F43D9E /* String+LocalizeTableName.swift */,
+				68973D651DA7AA200076F08A /* String+LocalizeBundle.swift */,
+				68973D6A1DA7AB140076F08A /* String+LocalizedBundleTableName.swift */,
 				3433F23B1C518AF7003AE34D /* Info.plist */,
 				343A6DE91D152B1B0081AA37 /* Localize_Swift-tvOS.plist */,
 				344169461C67539300B93D28 /* Foundation.framework */,
@@ -355,6 +367,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				68973D6B1DA7AB140076F08A /* String+LocalizedBundleTableName.swift in Sources */,
+				68973D661DA7AA200076F08A /* String+LocalizeBundle.swift in Sources */,
 				3433F2531C518B38003AE34D /* Localize.swift in Sources */,
 				68A520041DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */,
 			);
@@ -372,6 +386,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				68973D6C1DA7AB140076F08A /* String+LocalizedBundleTableName.swift in Sources */,
+				68973D671DA7AA200076F08A /* String+LocalizeBundle.swift in Sources */,
 				343A6DD11D1529560081AA37 /* Localize.swift in Sources */,
 				68A520051DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */,
 			);
@@ -381,6 +397,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				68973D6D1DA7AB140076F08A /* String+LocalizedBundleTableName.swift in Sources */,
+				68973D681DA7AA200076F08A /* String+LocalizeBundle.swift in Sources */,
 				343A6DDF1D152B1B0081AA37 /* Localize.swift in Sources */,
 				68A520061DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */,
 			);
@@ -390,6 +408,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				68973D6E1DA7AB140076F08A /* String+LocalizedBundleTableName.swift in Sources */,
+				68973D691DA7AA200076F08A /* String+LocalizeBundle.swift in Sources */,
 				343A6DEC1D152E5A0081AA37 /* Localize.swift in Sources */,
 				68A520071DA6D5FD00F43D9E /* String+LocalizeTableName.swift in Sources */,
 			);

--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -59,7 +59,7 @@ public extension String {
      - Returns: The localized string.
      */
     func localized() -> String {
-        return localized(using: nil)
+        return localized(using: nil, in: .main)
     }
 
     /**

--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -59,15 +59,7 @@ public extension String {
      - Returns: The localized string.
      */
     func localized() -> String {
-        if let path = Bundle.main.path(forResource: Localize.currentLanguage(), ofType: "lproj"),
-            let bundle = Bundle(path: path) {
-            return bundle.localizedString(forKey: self, value: nil, table: nil)
-        }
-        else if let path = Bundle.main.path(forResource: LCLBaseBundle, ofType: "lproj"),
-            let bundle = Bundle(path: path) {
-            return bundle.localizedString(forKey: self, value: nil, table: nil)
-        }
-        return self
+        return localized(using: nil)
     }
 
     /**

--- a/Sources/String+LocalizeBundle.swift
+++ b/Sources/String+LocalizeBundle.swift
@@ -10,45 +10,45 @@ import Foundation
 
 /// bundle friendly extension
 public extension String {
-	
-	/**
-	Swift 2 friendly localization syntax, replaces NSLocalizedString
-	
-	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
-	the method attempts to use main bundle.
-	
-	- Returns: The localized string.
-	*/
-	func localized(in bundle: Bundle?) -> String {
-		return localized(using: nil, in: bundle)
-	}
-	
-	/**
-	Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString)
-	
-	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
-	the method attempts to use main bundle.
-	
-	- Parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
-	
-	- Returns: The formatted localized string with arguments.
-	*/
-	func localizedFormat(in bundle: Bundle?, arguments: CVarArg...) -> String {
-		return String(format: localized(in: bundle), arguments: arguments)
-	}
-	
-	/**
-	Swift 2 friendly plural localization syntax with a format argument
-	
-	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
-	the method attempts to use main bundle.
-	
-	- parameter argument: Argument to determine pluralisation
-	
-	- returns: Pluralized localized string.
-	*/
-	func localizedPlural(in bundle: Bundle?, argument: CVarArg) -> String {
-		return NSString.localizedStringWithFormat(localized(in: bundle) as NSString, argument) as String
-	}
-	
+    
+    /**
+     Swift 2 friendly localization syntax, replaces NSLocalizedString.
+     
+     - parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+     the method attempts to use main bundle.
+     
+     - returns: The localized string.
+     */
+    func localized(in bundle: Bundle?) -> String {
+        return localized(using: nil, in: bundle)
+    }
+    
+    /**
+     Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString).
+     
+     - parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
+     
+     - parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+     the method attempts to use main bundle.
+     
+     - returns: The formatted localized string with arguments.
+     */
+    func localizedFormat(arguments: CVarArg..., in bundle: Bundle?) -> String {
+        return String(format: localized(in: bundle), arguments: arguments)
+    }
+    
+    /**
+     Swift 2 friendly plural localization syntax with a format argument.
+     
+     - parameter argument: Argument to determine pluralisation.
+     
+     - parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+     the method attempts to use main bundle.
+     
+     - returns: Pluralized localized string.
+     */
+    func localizedPlural(argument: CVarArg, in bundle: Bundle?) -> String {
+        return NSString.localizedStringWithFormat(localized(in: bundle) as NSString, argument) as String
+    }
+    
 }

--- a/Sources/String+LocalizeBundle.swift
+++ b/Sources/String+LocalizeBundle.swift
@@ -1,0 +1,54 @@
+//
+//  String+LocalizeBundle.swift
+//  Localize_Swift
+//
+//  Created by Vitalii Budnik on 10/7/16.
+//  Copyright © 2016 Roy Marmelstein. All rights reserved.
+//
+
+import Foundation
+
+/// bundle friendly extension
+public extension String {
+	
+	/**
+	Swift 2 friendly localization syntax, replaces NSLocalizedString
+	
+	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+	the method attempts to use main bundle.
+	
+	- Returns: The localized string.
+	*/
+	func localized(in bundle: Bundle?) -> String {
+		return localized(using: nil, in: bundle)
+	}
+	
+	/**
+	Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString)
+	
+	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+	the method attempts to use main bundle.
+	
+	- Parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
+	
+	- Returns: The formatted localized string with arguments.
+	*/
+	func localizedFormat(in bundle: Bundle?, arguments: CVarArg...) -> String {
+		return String(format: localized(in: bundle), arguments: arguments)
+	}
+	
+	/**
+	Swift 2 friendly plural localization syntax with a format argument
+	
+	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+	the method attempts to use main bundle.
+	
+	- parameter argument: Argument to determine pluralisation
+	
+	- returns: Pluralized localized string.
+	*/
+	func localizedPlural(in bundle: Bundle?, argument: CVarArg) -> String {
+		return NSString.localizedStringWithFormat(localized(in: bundle) as NSString, argument) as String
+	}
+	
+}

--- a/Sources/String+LocalizeTableName.swift
+++ b/Sources/String+LocalizeTableName.swift
@@ -12,42 +12,42 @@ import Foundation
 public extension String {
     
     /**
-     Swift 2 friendly localization syntax, replaces NSLocalizedString
+     Swift 2 friendly localization syntax, replaces NSLocalizedString.
      
-     - Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     - parameter tableName: The receiver’s string table to search. If tableName is `nil`
      or is an empty string, the method attempts to use `Localizable.strings`.
      
-     - Returns: The localized string.
+     - returns: The localized string.
      */
     func localized(using tableName: String?) -> String {
         return localized(using: tableName, in: .main)
     }
     
     /**
-     Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString)
+     Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString).
      
-     - Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     - parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
+
+     - parameter tableName: The receiver’s string table to search. If tableName is `nil`
      or is an empty string, the method attempts to use `Localizable.strings`.
      
-     - Parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
-     
-     - Returns: The formatted localized string with arguments.
+     - returns: The formatted localized string with arguments.
      */
-    func localizedFormat(using tableName: String?, arguments: CVarArg...) -> String {
+    func localizedFormat(arguments: CVarArg..., using tableName: String?) -> String {
         return String(format: localized(using: tableName), arguments: arguments)
     }
     
     /**
-     Swift 2 friendly plural localization syntax with a format argument
+     Swift 2 friendly plural localization syntax with a format argument.
      
-     - Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     - parameter argument: Argument to determine pluralisation.
+
+     - parameter tableName: The receiver’s string table to search. If tableName is `nil`
      or is an empty string, the method attempts to use `Localizable.strings`.
-     
-     - parameter argument: Argument to determine pluralisation
      
      - returns: Pluralized localized string.
      */
-    func localizedPlural(using tableName: String?, argument: CVarArg) -> String {
+    func localizedPlural(argument: CVarArg, using tableName: String?) -> String {
         return NSString.localizedStringWithFormat(localized(using: tableName) as NSString, argument) as String
     }
     

--- a/Sources/String+LocalizeTableName.swift
+++ b/Sources/String+LocalizeTableName.swift
@@ -20,15 +20,7 @@ public extension String {
      - Returns: The localized string.
      */
     func localized(using tableName: String?) -> String {
-        if let path = Bundle.main.path(forResource: Localize.currentLanguage(), ofType: "lproj"),
-            let bundle = Bundle(path: path) {
-            return bundle.localizedString(forKey: self, value: nil, table: tableName)
-        }
-        else if let path = Bundle.main.path(forResource: LCLBaseBundle, ofType: "lproj"),
-            let bundle = Bundle(path: path) {
-            return bundle.localizedString(forKey: self, value: nil, table: tableName)
-        }
-        return self
+        return localized(using: tableName, in: .main)
     }
     
     /**

--- a/Sources/String+LocalizeTableName.swift
+++ b/Sources/String+LocalizeTableName.swift
@@ -1,0 +1,62 @@
+//
+//  String+LocalizeTableName.swift
+//  Localize_Swift
+//
+//  Created by Vitalii Budnik on 3/10/16.
+//  Copyright © 2016 Vitalii Budnik. All rights reserved.
+//
+
+import Foundation
+
+/// tableName friendly extension
+public extension String {
+    
+    /**
+     Swift 2 friendly localization syntax, replaces NSLocalizedString
+     
+     - Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     or is an empty string, the method attempts to use `Localizable.strings`.
+     
+     - Returns: The localized string.
+     */
+    func localized(using tableName: String?) -> String {
+        if let path = Bundle.main.path(forResource: Localize.currentLanguage(), ofType: "lproj"),
+            let bundle = Bundle(path: path) {
+            return bundle.localizedString(forKey: self, value: nil, table: tableName)
+        }
+        else if let path = Bundle.main.path(forResource: LCLBaseBundle, ofType: "lproj"),
+            let bundle = Bundle(path: path) {
+            return bundle.localizedString(forKey: self, value: nil, table: tableName)
+        }
+        return self
+    }
+    
+    /**
+     Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString)
+     
+     - Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     or is an empty string, the method attempts to use `Localizable.strings`.
+     
+     - Parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
+     
+     - Returns: The formatted localized string with arguments.
+     */
+    func localizedFormat(using tableName: String?, arguments: CVarArg...) -> String {
+        return String(format: localized(using: tableName), arguments: arguments)
+    }
+    
+    /**
+     Swift 2 friendly plural localization syntax with a format argument
+     
+     - Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     or is an empty string, the method attempts to use `Localizable.strings`.
+     
+     - parameter argument: Argument to determine pluralisation
+     
+     - returns: Pluralized localized string.
+     */
+    func localizedPlural(using tableName: String?, argument: CVarArg) -> String {
+        return NSString.localizedStringWithFormat(localized(using: tableName) as NSString, argument) as String
+    }
+    
+}

--- a/Sources/String+LocalizedBundleTableName.swift
+++ b/Sources/String+LocalizedBundleTableName.swift
@@ -1,0 +1,72 @@
+//
+//  String+LocalizedBundleTableName.swift
+//  Localize_Swift
+//
+//  Created by Vitalii Budnik on 10/7/16.
+//  Copyright © 2016 Roy Marmelstein. All rights reserved.
+//
+
+import Foundation
+
+/// bundle & tableName friendly extension
+public extension String {
+	
+	/**
+	Swift 2 friendly localization syntax, replaces NSLocalizedString
+	
+	- Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+	or is an empty string, the method attempts to use `Localizable.strings`.
+
+	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+	the method attempts to use main bundle.
+	
+	- Returns: The localized string.
+	*/
+	func localized(using tableName: String?, in bundle: Bundle?) -> String {
+		let bundle: Bundle = bundle ?? .main
+		if let path = bundle.path(forResource: Localize.currentLanguage(), ofType: "lproj"),
+			let bundle = Bundle(path: path) {
+			return bundle.localizedString(forKey: self, value: nil, table: tableName)
+		}
+		else if let path = bundle.path(forResource: LCLBaseBundle, ofType: "lproj"),
+			let bundle = Bundle(path: path) {
+			return bundle.localizedString(forKey: self, value: nil, table: tableName)
+		}
+		return self
+	}
+	
+	/**
+	Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString)
+	
+	- Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+	or is an empty string, the method attempts to use `Localizable.strings`.
+
+	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+	the method attempts to use main bundle.
+	
+	- Parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
+	
+	- Returns: The formatted localized string with arguments.
+	*/
+	func localizedFormat(using tableName: String?, in bundle: Bundle?, arguments: CVarArg...) -> String {
+		return String(format: localized(using: tableName, in: bundle), arguments: arguments)
+	}
+	
+	/**
+	Swift 2 friendly plural localization syntax with a format argument
+	
+	- Parameter tableName: The receiver’s string table to search. If tableName is `nil`
+	or is an empty string, the method attempts to use `Localizable.strings`.
+
+	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+	the method attempts to use main bundle.
+	
+	- parameter argument: Argument to determine pluralisation
+	
+	- returns: Pluralized localized string.
+	*/
+	func localizedPlural(using tableName: String?, in bundle: Bundle?, argument: CVarArg) -> String {
+		return NSString.localizedStringWithFormat(localized(using: tableName, in: bundle) as NSString, argument) as String
+	}
+	
+}

--- a/Sources/String+LocalizedBundleTableName.swift
+++ b/Sources/String+LocalizedBundleTableName.swift
@@ -10,63 +10,63 @@ import Foundation
 
 /// bundle & tableName friendly extension
 public extension String {
-	
-	/**
-	Swift 2 friendly localization syntax, replaces NSLocalizedString
-	
-	- Parameter tableName: The receiver’s string table to search. If tableName is `nil`
-	or is an empty string, the method attempts to use `Localizable.strings`.
-
-	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
-	the method attempts to use main bundle.
-	
-	- Returns: The localized string.
-	*/
-	func localized(using tableName: String?, in bundle: Bundle?) -> String {
-		let bundle: Bundle = bundle ?? .main
-		if let path = bundle.path(forResource: Localize.currentLanguage(), ofType: "lproj"),
-			let bundle = Bundle(path: path) {
-			return bundle.localizedString(forKey: self, value: nil, table: tableName)
-		}
-		else if let path = bundle.path(forResource: LCLBaseBundle, ofType: "lproj"),
-			let bundle = Bundle(path: path) {
-			return bundle.localizedString(forKey: self, value: nil, table: tableName)
-		}
-		return self
-	}
-	
-	/**
-	Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString)
-	
-	- Parameter tableName: The receiver’s string table to search. If tableName is `nil`
-	or is an empty string, the method attempts to use `Localizable.strings`.
-
-	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
-	the method attempts to use main bundle.
-	
-	- Parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
-	
-	- Returns: The formatted localized string with arguments.
-	*/
-	func localizedFormat(using tableName: String?, in bundle: Bundle?, arguments: CVarArg...) -> String {
-		return String(format: localized(using: tableName, in: bundle), arguments: arguments)
-	}
-	
-	/**
-	Swift 2 friendly plural localization syntax with a format argument
-	
-	- Parameter tableName: The receiver’s string table to search. If tableName is `nil`
-	or is an empty string, the method attempts to use `Localizable.strings`.
-
-	- Parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
-	the method attempts to use main bundle.
-	
-	- parameter argument: Argument to determine pluralisation
-	
-	- returns: Pluralized localized string.
-	*/
-	func localizedPlural(using tableName: String?, in bundle: Bundle?, argument: CVarArg) -> String {
-		return NSString.localizedStringWithFormat(localized(using: tableName, in: bundle) as NSString, argument) as String
-	}
-	
+    
+    /**
+     Swift 2 friendly localization syntax, replaces NSLocalizedString.
+     
+     - parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     or is an empty string, the method attempts to use `Localizable.strings`.
+     
+     - parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+     the method attempts to use main bundle.
+     
+     - returns: The localized string.
+     */
+    func localized(using tableName: String?, in bundle: Bundle?) -> String {
+        let bundle: Bundle = bundle ?? .main
+        if let path = bundle.path(forResource: Localize.currentLanguage(), ofType: "lproj"),
+            let bundle = Bundle(path: path) {
+            return bundle.localizedString(forKey: self, value: nil, table: tableName)
+        }
+        else if let path = bundle.path(forResource: LCLBaseBundle, ofType: "lproj"),
+            let bundle = Bundle(path: path) {
+            return bundle.localizedString(forKey: self, value: nil, table: tableName)
+        }
+        return self
+    }
+    
+    /**
+     Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString).
+     
+     - parameter arguments: arguments values for temlpate (substituted according to the user’s default locale).
+     
+     - parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     or is an empty string, the method attempts to use `Localizable.strings`.
+     
+     - parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+     the method attempts to use main bundle.
+     
+     - returns: The formatted localized string with arguments.
+     */
+    func localizedFormat(arguments: CVarArg..., using tableName: String?, in bundle: Bundle?) -> String {
+        return String(format: localized(using: tableName, in: bundle), arguments: arguments)
+    }
+    
+    /**
+     Swift 2 friendly plural localization syntax with a format argument.
+     
+     - parameter argument: Argument to determine pluralisation.
+     
+     - parameter tableName: The receiver’s string table to search. If tableName is `nil`
+     or is an empty string, the method attempts to use `Localizable.strings`.
+     
+     - parameter bundle: The receiver’s bundle to search. If bundle is `nil`,
+     the method attempts to use main bundle.
+     
+     - returns: Pluralized localized string.
+     */
+    func localizedPlural(argument: CVarArg, using tableName: String?, in bundle: Bundle?) -> String {
+        return NSString.localizedStringWithFormat(localized(using: tableName, in: bundle) as NSString, argument) as String
+    }
+    
 }

--- a/examples/LanguageSwitch/.gitignore
+++ b/examples/LanguageSwitch/.gitignore
@@ -1,0 +1,2 @@
+Pods
+*.xcworkspace

--- a/examples/LanguageSwitch/Sample.xcodeproj/project.pbxproj
+++ b/examples/LanguageSwitch/Sample.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		34346D0A1B7294470063FED4 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 34346D091B7294470063FED4 /* Images.xcassets */; };
 		34346D0D1B7294470063FED4 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 34346D0B1B7294470063FED4 /* LaunchScreen.xib */; };
 		34346D2C1B72983C0063FED4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 34346D2F1B72983C0063FED4 /* Localizable.strings */; };
+		68A5200A1DA6D98000F43D9E /* ButtonTitles.strings in Resources */ = {isa = PBXBuildFile; fileRef = 68A5200C1DA6D98000F43D9E /* ButtonTitles.strings */; };
+		68A520181DA6DC0200F43D9E /* ButtonTitles.strings in Resources */ = {isa = PBXBuildFile; fileRef = 68A5200C1DA6D98000F43D9E /* ButtonTitles.strings */; };
+		8643E39F4C7E2705E0A6F9A7 /* Pods_SampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B823A35026E31B4C36949480 /* Pods_SampleTests.framework */; };
+		B17B53ED57A9B47A20D4B7B4 /* Pods_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 333B3261F84DF59D1EBBD7A4 /* Pods_Sample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,8 +32,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04BCF55C5CD131C12D56163D /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+		333B3261F84DF59D1EBBD7A4 /* Pods_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3426FF901BB6AEE200E8E1BB /* SampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		3426FF921BB6AEE200E8E1BB /* SampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleTests.swift; sourceTree = "<group>"; };
+		3426FF921BB6AEE200E8E1BB /* SampleTests.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SampleTests.swift; sourceTree = "<group>"; tabWidth = 4; usesTabs = 0; };
 		3426FF941BB6AEE200E8E1BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		34346CFD1B7294470063FED4 /* Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		34346D011B7294470063FED4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -46,6 +52,18 @@
 		34346D341B7298C60063FED4 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		34346D351B7298DD0063FED4 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		34346D361B7298E80063FED4 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
+		65FDC936EF4BBFD5021FC7E7 /* Pods-SampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SampleTests/Pods-SampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		68A5200B1DA6D98000F43D9E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ButtonTitles.strings; sourceTree = "<group>"; };
+		68A520111DA6DA3400F43D9E /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ButtonTitles.strings; sourceTree = "<group>"; };
+		68A520121DA6DA4100F43D9E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/ButtonTitles.strings; sourceTree = "<group>"; };
+		68A520131DA6DA5A00F43D9E /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/ButtonTitles.strings; sourceTree = "<group>"; };
+		68A520141DA6DA6C00F43D9E /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/ButtonTitles.strings; sourceTree = "<group>"; };
+		68A520151DA6DA7A00F43D9E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/ButtonTitles.strings; sourceTree = "<group>"; };
+		68A520161DA6DA8900F43D9E /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/ButtonTitles.strings"; sourceTree = "<group>"; };
+		68A520171DA6DA9600F43D9E /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/ButtonTitles.strings; sourceTree = "<group>"; };
+		9A631F677754425453518C07 /* Pods-SampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SampleTests/Pods-SampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		B823A35026E31B4C36949480 /* Pods_SampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E538D5A6F7CE2B5339266A69 /* Pods-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.release.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +71,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8643E39F4C7E2705E0A6F9A7 /* Pods_SampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -60,12 +79,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B17B53ED57A9B47A20D4B7B4 /* Pods_Sample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1296D3EDC6FA72EB325EB960 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				333B3261F84DF59D1EBBD7A4 /* Pods_Sample.framework */,
+				B823A35026E31B4C36949480 /* Pods_SampleTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		3426FF911BB6AEE200E8E1BB /* SampleTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -81,6 +110,8 @@
 				34346CFF1B7294470063FED4 /* Sample */,
 				3426FF911BB6AEE200E8E1BB /* SampleTests */,
 				34346CFE1B7294470063FED4 /* Products */,
+				D54087AB05FC5C7ADB2A7033 /* Pods */,
+				1296D3EDC6FA72EB325EB960 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -118,9 +149,21 @@
 		34346D281B7297820063FED4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				68A5200C1DA6D98000F43D9E /* ButtonTitles.strings */,
 				34346D2F1B72983C0063FED4 /* Localizable.strings */,
 			);
 			name = Resources;
+			sourceTree = "<group>";
+		};
+		D54087AB05FC5C7ADB2A7033 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				04BCF55C5CD131C12D56163D /* Pods-Sample.debug.xcconfig */,
+				E538D5A6F7CE2B5339266A69 /* Pods-Sample.release.xcconfig */,
+				9A631F677754425453518C07 /* Pods-SampleTests.debug.xcconfig */,
+				65FDC936EF4BBFD5021FC7E7 /* Pods-SampleTests.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -130,9 +173,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3426FF971BB6AEE200E8E1BB /* Build configuration list for PBXNativeTarget "SampleTests" */;
 			buildPhases = (
+				A160DBF99A41543AA58B4013 /* [CP] Check Pods Manifest.lock */,
 				3426FF8C1BB6AEE200E8E1BB /* Sources */,
 				3426FF8D1BB6AEE200E8E1BB /* Frameworks */,
 				3426FF8E1BB6AEE200E8E1BB /* Resources */,
+				328637D3D71CB227675DBFD2 /* [CP] Embed Pods Frameworks */,
+				BF7F9B813A8AD97AB232C765 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -148,9 +194,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 34346D1C1B7294470063FED4 /* Build configuration list for PBXNativeTarget "Sample" */;
 			buildPhases = (
+				2DEBC8A4D7DB91A2D297143C /* [CP] Check Pods Manifest.lock */,
 				34346CF91B7294470063FED4 /* Sources */,
 				34346CFA1B7294470063FED4 /* Frameworks */,
 				34346CFB1B7294470063FED4 /* Resources */,
+				9A39A510A640F0F95E3652A1 /* [CP] Embed Pods Frameworks */,
+				A5D1FC4CD91FC14C7C5CB22C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -214,6 +263,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3426FF9B1BB6AF5D00E8E1BB /* Localizable.strings in Resources */,
+				68A520181DA6DC0200F43D9E /* ButtonTitles.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,12 +273,106 @@
 			files = (
 				34346D081B7294470063FED4 /* Main.storyboard in Resources */,
 				34346D2C1B72983C0063FED4 /* Localizable.strings in Resources */,
+				68A5200A1DA6D98000F43D9E /* ButtonTitles.strings in Resources */,
 				34346D0D1B7294470063FED4 /* LaunchScreen.xib in Resources */,
 				34346D0A1B7294470063FED4 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2DEBC8A4D7DB91A2D297143C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		328637D3D71CB227675DBFD2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SampleTests/Pods-SampleTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9A39A510A640F0F95E3652A1 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A160DBF99A41543AA58B4013 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		A5D1FC4CD91FC14C7C5CB22C /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Sample/Pods-Sample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BF7F9B813A8AD97AB232C765 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SampleTests/Pods-SampleTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		3426FF8C1BB6AEE200E8E1BB /* Sources */ = {
@@ -290,11 +434,27 @@
 			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
+		68A5200C1DA6D98000F43D9E /* ButtonTitles.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				68A5200B1DA6D98000F43D9E /* en */,
+				68A520111DA6DA3400F43D9E /* fr */,
+				68A520121DA6DA4100F43D9E /* de */,
+				68A520131DA6DA5A00F43D9E /* es */,
+				68A520141DA6DA6C00F43D9E /* it */,
+				68A520151DA6DA7A00F43D9E /* ja */,
+				68A520161DA6DA8900F43D9E /* zh-Hans */,
+				68A520171DA6DA9600F43D9E /* he */,
+			);
+			name = ButtonTitles.strings;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		3426FF981BB6AEE200E8E1BB /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9A631F677754425453518C07 /* Pods-SampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -311,6 +471,7 @@
 		};
 		3426FF991BB6AEE200E8E1BB /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 65FDC936EF4BBFD5021FC7E7 /* Pods-SampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -415,6 +576,7 @@
 		};
 		34346D1D1B7294470063FED4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 04BCF55C5CD131C12D56163D /* Pods-Sample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -428,6 +590,7 @@
 		};
 		34346D1E1B7294470063FED4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E538D5A6F7CE2B5339266A69 /* Pods-Sample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";

--- a/examples/LanguageSwitch/Sample/ViewController.swift
+++ b/examples/LanguageSwitch/Sample/ViewController.swift
@@ -42,8 +42,8 @@ class ViewController: UIViewController {
     
     func setText(){
         textLabel.text = "Hello world".localized();
-        changeButton.setTitle("Change".localized(), for: UIControlState.normal)
-        resetButton.setTitle("Reset".localized(), for: UIControlState.normal)
+			changeButton.setTitle("Change".localized(using: "ButtonTitles"), for: UIControlState.normal)
+        resetButton.setTitle("Reset".localized(using: "ButtonTitles"), for: UIControlState.normal)
     }
     
     // MARK: IBActions

--- a/examples/LanguageSwitch/Sample/de.lproj/ButtonTitles.strings
+++ b/examples/LanguageSwitch/Sample/de.lproj/ButtonTitles.strings
@@ -6,4 +6,6 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Hello world" = "你好世界";
+"Change" = "Ändern";
+
+"Reset" = "Umkehren";

--- a/examples/LanguageSwitch/Sample/de.lproj/Localizable.strings
+++ b/examples/LanguageSwitch/Sample/de.lproj/Localizable.strings
@@ -6,8 +6,4 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Change" = "Ändern";
-
 "Hello world" = "Hallo Welt";
-
-"Reset" = "Umkehren";

--- a/examples/LanguageSwitch/Sample/en.lproj/ButtonTitles.strings
+++ b/examples/LanguageSwitch/Sample/en.lproj/ButtonTitles.strings
@@ -1,0 +1,11 @@
+/* 
+  ButtonTitles.strings
+  Sample
+
+  Created by Vitalii Budnik on 10/6/16.
+  Copyright © 2016 Roy Marmelstein. All rights reserved.
+*/
+
+"Change" = "Change";
+
+"Reset" = "Reset";

--- a/examples/LanguageSwitch/Sample/en.lproj/Localizable.strings
+++ b/examples/LanguageSwitch/Sample/en.lproj/Localizable.strings
@@ -6,8 +6,4 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Change" = "Change";
-
 "Hello world" = "Hello world";
-
-"Reset" = "Reset";

--- a/examples/LanguageSwitch/Sample/es.lproj/ButtonTitles.strings
+++ b/examples/LanguageSwitch/Sample/es.lproj/ButtonTitles.strings
@@ -6,4 +6,6 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Hello world" = "你好世界";
+"Change" = "Cambiar";
+
+"Reset" = "Reiniciar";

--- a/examples/LanguageSwitch/Sample/es.lproj/Localizable.strings
+++ b/examples/LanguageSwitch/Sample/es.lproj/Localizable.strings
@@ -6,8 +6,4 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Change" = "Cambiar";
-
 "Hello world" = "Hola mundo";
-
-"Reset" = "Reiniciar";

--- a/examples/LanguageSwitch/Sample/fr.lproj/ButtonTitles.strings
+++ b/examples/LanguageSwitch/Sample/fr.lproj/ButtonTitles.strings
@@ -1,0 +1,11 @@
+/* 
+  ButtonTitles.strings
+  Sample
+
+  Created by Vitalii Budnik on 10/6/16.
+  Copyright © 2016 Roy Marmelstein. All rights reserved.
+*/
+
+"Change" = "Modifier";
+
+"Reset" = "Réinitialiser";

--- a/examples/LanguageSwitch/Sample/fr.lproj/Localizable.strings
+++ b/examples/LanguageSwitch/Sample/fr.lproj/Localizable.strings
@@ -6,8 +6,4 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Change" = "Modifier";
-
 "Hello world" = "Bonjour le monde";
-
-"Reset" = "Réinitialiser";

--- a/examples/LanguageSwitch/Sample/he.lproj/ButtonTitles.strings
+++ b/examples/LanguageSwitch/Sample/he.lproj/ButtonTitles.strings
@@ -6,4 +6,6 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Hello world" = "你好世界";
+"Change" = "שינוי";
+
+"Reset" = "אתחל";

--- a/examples/LanguageSwitch/Sample/he.lproj/Localizable.strings
+++ b/examples/LanguageSwitch/Sample/he.lproj/Localizable.strings
@@ -6,8 +6,4 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Change" = "שינוי";
-
 "Hello world" = "שלום עולם";
-
-"Reset" = "אתחל";

--- a/examples/LanguageSwitch/Sample/it.lproj/ButtonTitles.strings
+++ b/examples/LanguageSwitch/Sample/it.lproj/ButtonTitles.strings
@@ -6,4 +6,6 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Hello world" = "你好世界";
+"Change" = "Cambia";
+
+"Reset" = "Ripristinare";

--- a/examples/LanguageSwitch/Sample/it.lproj/Localizable.strings
+++ b/examples/LanguageSwitch/Sample/it.lproj/Localizable.strings
@@ -6,8 +6,4 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Change" = "Cambia";
-
 "Hello world" = "Ciao mondo";
-
-"Reset" = "Ripristinare";

--- a/examples/LanguageSwitch/Sample/ja.lproj/ButtonTitles.strings
+++ b/examples/LanguageSwitch/Sample/ja.lproj/ButtonTitles.strings
@@ -6,4 +6,6 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Hello world" = "你好世界";
+"Change" = "変更します";
+
+"Reset" = "リセットします";

--- a/examples/LanguageSwitch/Sample/ja.lproj/Localizable.strings
+++ b/examples/LanguageSwitch/Sample/ja.lproj/Localizable.strings
@@ -6,8 +6,4 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Change" = "変更します";
-
 "Hello world" = "こんにちは世界";
-
-"Reset" = "リセットします";

--- a/examples/LanguageSwitch/Sample/zh-Hans.lproj/ButtonTitles.strings
+++ b/examples/LanguageSwitch/Sample/zh-Hans.lproj/ButtonTitles.strings
@@ -6,4 +6,6 @@
   Copyright (c) 2015 Roy Marmelstein. All rights reserved.
 */
 
-"Hello world" = "你好世界";
+"Change" = "改变";
+
+"Reset" = "重置";

--- a/examples/LanguageSwitch/SampleTests/SampleTests.swift
+++ b/examples/LanguageSwitch/SampleTests/SampleTests.swift
@@ -52,5 +52,28 @@ class SampleTests: XCTestCase {
         XCTAssertEqual(testString.localized(), "Non translated string")
     }
 
+	func testTableName() {
+		let testString = "Change";
+		Localize.setCurrentLanguage("fr")
+        let translatedString = testString.localized(using: "ButtonTitles")
+		XCTAssertEqual(translatedString, "Modifier")
+	}
+	
+    func testTableNameMultipleLanguage() {
+        let testString = "Change";
+        Localize.setCurrentLanguage("es")
+        XCTAssertEqual(testString.localized(using: "ButtonTitles"), "Cambiar")
+        Localize.setCurrentLanguage("de")
+        XCTAssertEqual(testString.localized(using: "ButtonTitles"), "Ändern")
+        Localize.resetCurrentLanguageToDefault()
+        XCTAssertEqual(testString.localized(using: "ButtonTitles"), "Change")
+    }
     
+    func testTableNameFail() {
+        let testString = "Change";
+        Localize.setCurrentLanguage("xxx")
+        let translatedString = testString.localized(using: "ButtonTitles")
+        XCTAssertEqual(translatedString, "Change")
+    }
+
 }


### PR DESCRIPTION
In complex projects, it's better to split strings into several files ("tables"), than to use one huge file.
Added ability to use Localize-Swift in frameworks.

Here is pull request with 4 commits:
1. Added support for "tableName" parameter. Syntax: `localized(using: "PassYoursTableNameHere")`
2. Added `localized(using: "TableName")` example & tests.
3. Added bundle support. Syntax: `localized(in: bundle)` && `localized(using: "PassYoursTableNameHere", in: bundle)`.
4. Moved arguments on the first place. Syntax: `.localizedFormat(arguments: arg1, arg2, arg3, arg4, using: "TableName", in: .main)`
