### PR TITLE
change display name key

### DIFF
--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -166,7 +166,7 @@ open class Localize: NSObject {
      */
     open class func displayNameForLanguage(_ language: String) -> String {
         let locale : NSLocale = NSLocale(localeIdentifier: currentLanguage())
-        if let displayName = (locale as NSLocale).displayName(forKey: NSLocale.Key.languageCode, value: language) {
+        if let displayName = locale.displayName(forKey: NSLocale.Key.identifier, value: language) {
             return displayName
         }
         return String()

--- a/examples/LanguageSwitch/Sample.xcodeproj/project.pbxproj
+++ b/examples/LanguageSwitch/Sample.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		20D57BE01DC0AF00001BA2F9 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		3426FF901BB6AEE200E8E1BB /* SampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3426FF921BB6AEE200E8E1BB /* SampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleTests.swift; sourceTree = "<group>"; };
 		3426FF941BB6AEE200E8E1BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -196,6 +197,7 @@
 				ja,
 				"zh-Hans",
 				he,
+				"zh-Hant",
 			);
 			mainGroup = 34346CF41B7294470063FED4;
 			productRefGroup = 34346CFE1B7294470063FED4 /* Products */;
@@ -286,6 +288,7 @@
 				34346D341B7298C60063FED4 /* ja */,
 				34346D351B7298DD0063FED4 /* zh-Hans */,
 				34346D361B7298E80063FED4 /* he */,
+				20D57BE01DC0AF00001BA2F9 /* zh-Hant */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/examples/LanguageSwitch/Sample/zh-Hant.lproj/Localizable.strings
+++ b/examples/LanguageSwitch/Sample/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,13 @@
+/* 
+  Localizable.strings
+  Sample
+
+  Created by Roy Marmelstein on 05/08/2015.
+  Copyright (c) 2015 Roy Marmelstein. All rights reserved.
+*/
+
+"Change" = "改變";
+
+"Hello world" = "你好世界";
+
+"Reset" = "重置";


### PR DESCRIPTION
The old key `NSLocale.Key.languageCode` will display both `zh-Hant` and `zh-Hans` as `Chinese`. It made me confuse when choosing the fit language for me.
I changed to use `NSLocale.Key.identifier` so it will show `Chinese (Traditional)` and `Chinese (Simplified)`.
I also added zh-Hant language file so while playing Example, you can see the difference.
Please see the different screenshot below

![olddisplay](https://cloud.githubusercontent.com/assets/745400/19720952/e326250a-9ba2-11e6-9621-4d1dfdaed577.png)
![newdisplay](https://cloud.githubusercontent.com/assets/745400/19720957/e79f6402-9ba2-11e6-8a31-233001b628cd.png)
