### PR TITLE
Support for comments in Swift 3

### DIFF
--- a/Localize_SwiftTests/test/test.swift
+++ b/Localize_SwiftTests/test/test.swift
@@ -1,0 +1,8 @@
+"sans comment".localized()
+"awesome".localized("comment")
+let fubar = "harmlessString"
+
+
+"awesome".localized("comment")
+
+"awesome".localized("comment different")

--- a/Localize_SwiftTests/test/test_two.swift
+++ b/Localize_SwiftTests/test/test_two.swift
@@ -1,0 +1,3 @@
+"awesome".localized("comment")
+
+"awesome".localized("comment different 2")

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Add `.localized()` following any `String` object you want translated:
 textLabel.text = "Hello World".localized()
 ```
 
+To include helpful comments alongside each localization, simply add it as a `String` parameter to the call in `.localized()`:
+```swift
+textLabel.text = "Hello World".localized("This will be displayed in the main screen")
+```
+
 To get an array of available localizations:
 ```swift
 Localize.availableLanguages()

--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -58,7 +58,7 @@ public extension String {
      Swift 2 friendly localization syntax, replaces NSLocalizedString
      - Returns: The localized string.
      */
-    func localized() -> String {
+    func localized(comment: String = "") -> String {
         return localized(using: nil, in: .main)
     }
 


### PR DESCRIPTION
This adds some basic support for adding comments to the translations.

Also, possibility to define several different comments for each translatable key is available. These stack up in the final output the same way classic `genstrings` does.

Some very rudimentary tests where included.
