### PR TITLE
Allow localizing Double-quoted strings using genstrings.swift

### DIFF
--- a/genstrings.swift
+++ b/genstrings.swift
@@ -11,7 +11,7 @@ class GenStrings {
     let excludedFileNames = ["genstrings.swift"]
     var regularExpresions = [String:NSRegularExpression]()
 
-    let localizedRegex = "(?<=\")([^\"]*)(?=\".(localized|localizedFormat))|(?<=(Localized|NSLocalizedString)\\(\")([^\"]*?)(?=\")"
+    let localizedRegex = "(?<=\")(.*?)(?=\".(localized|localizedFormat))|(?<=(Localized|NSLocalizedString)\\(\")([^\"]*?)(?=\")"
 
     enum GenstringsError: Error {
         case Error


### PR DESCRIPTION
The previous regular expression in `genstrings.swift` doesn't support capturing strings such as "Please tap \"Allow\" to continue".

This fix solves this issue. I've tested it on my own project with diff and had no issues.