### PR TITLE
fix to get the system's language by default and not the language bundle

### DIFF
--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -131,7 +131,7 @@ open class Localize: NSObject {
      */
     open class func defaultLanguage() -> String {
         var defaultLanguage: String = String()
-        guard let preferredLanguage = Bundle.main.preferredLocalizations.first else {
+        guard let preferredLanguage = Locale.current.languageCode else {
             return LCLDefaultLanguage
         }
         let availableLanguages: [String] = self.availableLanguages()


### PR DESCRIPTION
I had an issue for a project i'm developing, my base language is in english but my testing device is in french and by default Localize-Swift take the base language. It causes a problem on the first install of the app.
I'm not sure if it's a good fix but it works :) 

Sorry for my poor english skills