### PR TITLE
Added support for "*.h" and "*.m" files.

### DIFF
--- a/genstrings.swift
+++ b/genstrings.swift
@@ -6,7 +6,7 @@ class GenStrings {
 
     var str = "Hello, playground"
     let fileManager = FileManager.default
-    let acceptedFileExtensions = ["swift"]
+    let acceptedFileExtensions = ["swift", "h", "m"]
     let excludedFolderNames = ["Carthage"]
     let excludedFileNames = ["genstrings.swift"]
     var regularExpresions = [String:NSRegularExpression]()


### PR DESCRIPTION
Added support for "*.h" and "*.m" files at genstrings.swift file. 

Devs will be able to read localised strings at objc files via this updated script.

To be able to use this, there should be ".localised" support at obj-c codes.