### PR TITLE
Layout semantics

### DIFF
--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -141,6 +141,8 @@ open class Localize: NSObject {
                     switch direction {
                     case .rightToLeft:
                         UIView.appearance().semanticContentAttribute = .forceRightToLeft
+                    case .leftToRight:
+                        UIView.appearance().semanticContentAttribute = .forceLeftToRight
                     default:
                         break
                     }

--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -24,10 +24,10 @@ public let LCLLanguageChangeNotification = "LCLLanguageChangeNotification"
 // MARK: Localization Syntax
 
 /**
-Swift 1.x friendly localization syntax, replaces NSLocalizedString
-- Parameter string: Key to be localized.
-- Returns: The localized string.
-*/
+ Swift 1.x friendly localization syntax, replaces NSLocalizedString
+ - Parameter string: Key to be localized.
+ - Returns: The localized string.
+ */
 public func Localized(_ string: String) -> String {
     return string.localized()
 }
@@ -62,7 +62,7 @@ public extension String {
     func localized() -> String {
         return localized(using: nil, in: .main)
     }
-
+    
     /**
      Swift 2 friendly localization syntax with format arguments, replaces String(format:NSLocalizedString)
      - Returns: The formatted localized string with arguments.
@@ -89,8 +89,8 @@ public extension String {
 
 open class Localize: NSObject {
     // Set appearnce language direction responsnding
-    public var changeSemantics = false
-
+    public static var changeSemantics = false
+    
     /**
      List available languages
      - Returns: Array of available languages.
@@ -127,10 +127,15 @@ open class Localize: NSObject {
             NotificationCenter.default.post(name: Notification.Name(rawValue: LCLLanguageChangeNotification), object: nil)
             if changeSemantics, selectedLanguage == "ar"{
                 if #available(iOSApplicationExtension 9.0, *) {
-                    UIView.appearance().semanticContentAttribute = .forceRightToLeft
-                } else {
-                    // TODO: - Fallback on earlier versions
-                    //
+                    if #available(iOS 9.0, *) {
+                        let direction = Locale.characterDirection(forLanguage: selectedLanguage)
+                        switch direction {
+                        case .rightToLeft:
+                            UIView.appearance().semanticContentAttribute = .forceRightToLeft
+                        default:
+                            break
+                        }
+                    }
                 }
             }
         }

--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Internal current language key
 let LCLCurrentLanguageKey = "LCLCurrentLanguageKey"
@@ -20,6 +21,9 @@ let LCLBaseBundle = "Base"
 /// Name for language change notification
 public let LCLLanguageChangeNotification = "LCLLanguageChangeNotification"
 
+// Set appearnce language direction responsnding
+
+public var changeSemantics = false
 // MARK: Localization Syntax
 
 /**
@@ -122,6 +126,14 @@ open class Localize: NSObject {
             UserDefaults.standard.set(selectedLanguage, forKey: LCLCurrentLanguageKey)
             UserDefaults.standard.synchronize()
             NotificationCenter.default.post(name: Notification.Name(rawValue: LCLLanguageChangeNotification), object: nil)
+            if changeSemantics, selectedLanguage == "ar"{
+                if #available(iOSApplicationExtension 9.0, *) {
+                    UIView.appearance().semanticContentAttribute = .forceRightToLeft
+                } else {
+                    // TODO: - Fallback on earlier versions
+                    //
+                }
+            }
         }
     }
     

--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -21,9 +21,6 @@ let LCLBaseBundle = "Base"
 /// Name for language change notification
 public let LCLLanguageChangeNotification = "LCLLanguageChangeNotification"
 
-// Set appearnce language direction responsnding
-
-public var changeSemantics = false
 // MARK: Localization Syntax
 
 /**
@@ -91,7 +88,9 @@ public extension String {
 // MARK: Language Setting Functions
 
 open class Localize: NSObject {
-    
+    // Set appearnce language direction responsnding
+    public var changeSemantics = false
+
     /**
      List available languages
      - Returns: Array of available languages.

--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -89,7 +89,11 @@ public extension String {
 
 open class Localize: NSObject {
     // Set appearnce language direction responsnding
-    public static var changeSemantics = false
+    public static var changeSemantics = false {
+        didSet{
+            updateAppSemantics(currentLanguage())
+        }
+    }
     
     /**
      List available languages
@@ -125,16 +129,20 @@ open class Localize: NSObject {
             UserDefaults.standard.set(selectedLanguage, forKey: LCLCurrentLanguageKey)
             UserDefaults.standard.synchronize()
             NotificationCenter.default.post(name: Notification.Name(rawValue: LCLLanguageChangeNotification), object: nil)
-            if changeSemantics, selectedLanguage == "ar"{
-                if #available(iOSApplicationExtension 9.0, *) {
-                    if #available(iOS 9.0, *) {
-                        let direction = Locale.characterDirection(forLanguage: selectedLanguage)
-                        switch direction {
-                        case .rightToLeft:
-                            UIView.appearance().semanticContentAttribute = .forceRightToLeft
-                        default:
-                            break
-                        }
+           
+        }
+    }
+    
+    open class func updateAppSemantics(_ language: String) {
+        if changeSemantics {
+            if #available(iOSApplicationExtension 9.0, *) {
+                if #available(iOS 9.0, *) {
+                    let direction = Locale.characterDirection(forLanguage: language)
+                    switch direction {
+                    case .rightToLeft:
+                        UIView.appearance().semanticContentAttribute = .forceRightToLeft
+                    default:
+                        break
                     }
                 }
             }

--- a/Sources/String+LocalizedBundleTableName.swift
+++ b/Sources/String+LocalizedBundleTableName.swift
@@ -24,7 +24,7 @@ public extension String {
      */
     func localized(using tableName: String?, in bundle: Bundle?) -> String {
         let bundle: Bundle = bundle ?? .main
-        if let path = bundle.path(forResource: Localize.currentLanguage(), ofType: "lproj"),
+        if let path = bundle.path(forResource: Localize.currentLanguage, ofType: "lproj"),
             let bundle = Bundle(path: path) {
             return bundle.localizedString(forKey: self, value: nil, table: tableName)
         }


### PR DESCRIPTION
I've been working with this library lately and I've faced semantics issue that wasn't flipped automatically whenever I change the language, so I added it, also I rewrote the currentlanguage to be a variable instead of function to be more swiftly. 

also new functionality comes as a property to be sit if user didn't want it, and it can be sit within appdelegate:

`        Localize.changeSemantics = true
`

hopefully everyone finds this useful, thanks! 