### PR TITLE
Add comments support for localization

### DIFF
--- a/Sources/Localize.swift
+++ b/Sources/Localize.swift
@@ -80,6 +80,14 @@ public extension String {
     func localizedPlural(_ argument: CVarArg) -> String {
         return NSString.localizedStringWithFormat(localized() as NSString, argument) as String
     }
+
+    /**
+     Add comment for NSLocalizedString
+     - Returns: The localized string.
+    */
+    func commented(_ argument: String) -> String {
+        return self
+    }
 }
 
 


### PR DESCRIPTION
## Changes
- Add `commented` function in String extension and returns `self`.
- Match strings in `commented` as comment for localization.
- Associate comment with closest precedent localized string.

## Sample
`"Hello".localized().commented("World!")`

**Output:**
```
/* World! */
"Hello" = "Hello";
```
