### PR TITLE
Delete removeObserver(self) line as in upper swift 4 theres no need to use it

### DIFF
--- a/examples/LanguageSwitch/Sample/ViewController.swift
+++ b/examples/LanguageSwitch/Sample/ViewController.swift
@@ -35,7 +35,6 @@ class ViewController: UIViewController {
     // Remove the LCLLanguageChangeNotification on viewWillDisappear
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        NotificationCenter.default.removeObserver(self)
     }
     
     // MARK: Localized Text


### PR DESCRIPTION
Hey Roy, 

I play with the library and example project helped me a lot to get into and play with the language switch feature but I notice that as you know, there's no need to use removeObserver in newer versions of the Swift Language. 

I test it with updating pod and it works.