### PR TITLE
Xcode14.3 Report error `use of '@import' in framework header is disco…

### DIFF
--- a/Sources/Localize_Swift.h
+++ b/Sources/Localize_Swift.h
@@ -6,7 +6,14 @@
 //  Copyright © 2020 Roy Marmelstein. All rights reserved.
 //
 
+#if __has_feature(modules)
+
+#if __has_warning("-Watimport-in-framework-header")
+#pragma clang diagnostic ignored "-Watimport-in-framework-header"
+#endif
 @import Foundation;
+#endif
+
 
 //! Project version number for Localize_Swift.
 FOUNDATION_EXPORT double Localize_SwiftVersionNumber;


### PR DESCRIPTION
…uraged, including this header requires -fmodules`

Xcode14.3 Report error use of '@import' in framework header is discouraged, including this header requires -fmodules

Xcode 11.4 turns the -Watimport-in-framework-header warning on by default. Using @import in framework headers is discouraged, because doing so requires all importers to use modules.

https://developer.apple.com/documentation/xcode-release-notes/xcode-11_4-release-notes